### PR TITLE
Add high-signal AGENTS.md for IntentGuard repository context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,46 @@
+# AGENTS.md
+
+IntentGuard is a **library for natural-language code assertions**. Keep changes small, composable, and focused on the runtime package unless explicitly asked otherwise.
+
+## What matters most
+
+- Public API surface is intentionally tiny: `IntentGuard` + `IntentGuardOptions`. Preserve this unless a task explicitly expands API.
+- The runtime uses three replaceable collaborators:
+  - `InferenceProvider` (model backend)
+  - `PromptFactory` (prompt construction)
+  - `JudgementCache` (result caching)
+- Default wiring happens at import time in `intentguard/__init__.py`.
+
+## Repository map (high signal only)
+
+- `intentguard/` — production Python package.
+  - `app/` — orchestration + interfaces (core control flow lives here).
+  - `domain/` — pure data and judgement logic.
+  - `infrastructure/` — filesystem cache + local llamafile backend + prompt template.
+- `tests/` — integration-style tests using the real `IntentGuard` API.
+- `validation/` — separate model-quality evaluation tooling and docs.
+- `ai_research/` — dataset generation and model-training artifacts (not required for normal library runtime work).
+
+## Core runtime flow
+
+1. `assert_code()` delegates to `test_code()`.
+2. `params` objects are converted to source snippets via `CodeObject.from_dict()`.
+3. Prompt is built by the configured `PromptFactory`.
+4. Cache lookup (`JudgementCache.get`) runs before inference.
+5. On miss, provider runs `num_evaluations` predictions.
+6. `Judge` applies majority vote and returns `Evaluation`.
+7. Result is cached and optionally raised as `AssertionError` when false.
+
+## Design constraints to preserve
+
+- `Judge` currently implements **strict majority** (`True > False`), so ties evaluate to false.
+- Cache keys include prompt + inference options + judgement options and are versioned (`v2:` prefix in FS cache).
+- Llamafile backend is lazy-initialized and stores artifacts under `.intentguard/`.
+- `IntentGuardOptions` controls deterministic behavior via `num_evaluations` and `temperature`.
+
+## Practical guidance for future edits
+
+- Prefer changing abstractions in `app/` or `domain/` before touching infrastructure details.
+- Keep infrastructure side effects explicit (downloads/process startup/cache writes).
+- Avoid broad refactors across `ai_research/` unless the task is explicitly research/training-related.
+- Preserve type hints and dataclass-based DTOs for low-token readability and maintainability.


### PR DESCRIPTION
### Motivation

- Provide a compact, high-signal guide for future coding agents so they can make safe, low-context edits without needing repository-wide onboarding. 
- Capture the runtime boundaries and constraints to reduce risky or high-cost changes to infrastructure and model-related code.

### Description

- Add a new root `AGENTS.md` that documents the public API surface (`IntentGuard`, `IntentGuardOptions`), the three replaceable collaborators (`InferenceProvider`, `PromptFactory`, `JudgementCache`), and default wiring at import time. 
- Summarize the core runtime flow from `assert_code()` -> `test_code()` -> `CodeObject.from_dict()` -> prompt creation -> `JudgementCache.get()` -> provider `predict()` (x `num_evaluations`) -> `Judge` majority voting -> cache and optional `AssertionError`. 
- Call out key design constraints and practical edit guidance such as `Judge` majority semantics (ties fail), cache key versioning (`v2:` prefix), lazy llamafile initialization and storage under `.intentguard/`, and preference to change `app/` or `domain/` before `infrastructure/`.

### Testing

- Ran `python -m compileall intentguard` to verify the package modules compile successfully, and the command completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e260f28314832c8c6afe17a58313f2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation outlining design constraints, operational principles, and repository structure for future development and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->