### PR TITLE
Limit llamafile 0.10 server concurrency

### DIFF
--- a/intentguard/infrastructure/llamafile.py
+++ b/intentguard/infrastructure/llamafile.py
@@ -174,6 +174,8 @@ class Llamafile(InferenceProvider):
                 "127.0.0.1",
                 "--port",
                 str(self._port),
+                "-np",
+                "1",
             ]
 
             system = platform.system()


### PR DESCRIPTION
llamafile 0.10 now auto-selects multiple parallel slots by default, which changes local backend behavior and memory usage compared with 0.9. Pinning -np 1 restores single-slot execution so IntentGuard starts the embedded server more predictably.