### PR TITLE
Use IntentGuard's real prompt generation in validation

### DIFF
--- a/validation/helpers.py
+++ b/validation/helpers.py
@@ -3,11 +3,8 @@ from typing import List, Optional
 from intentguard.app.inference_options import InferenceOptions
 from intentguard.app.judgement_cache import JudgementCache
 from intentguard.app.message import Message
-from intentguard.app.prompt_factory import PromptFactory
-from intentguard.domain.code_object import CodeObject
 from intentguard.domain.evaluation import Evaluation
 from intentguard.domain.judgement_options import JudgementOptions
-from intentguard.infrastructure.prompt_text import SYSTEM_PROMPT
 
 
 class NullJudgementCache(JudgementCache):
@@ -27,14 +24,3 @@ class NullJudgementCache(JudgementCache):
         judgement: Evaluation,
     ) -> None:
         return None
-
-
-class PassthroughPromptFactory(PromptFactory):
-    def create_prompt(
-        self, expectation: str, code_objects: List[CodeObject]
-    ) -> List[Message]:
-        del code_objects
-        return [
-            Message(content=SYSTEM_PROMPT, role="system"),
-            Message(content=expectation, role="user"),
-        ]

--- a/validation/validate.py
+++ b/validation/validate.py
@@ -1,61 +1,103 @@
-import json
+import linecache
 import logging
+import types
+from typing import Any, Dict, Optional
 
 from datasets import load_dataset
 from tqdm import tqdm
 
 import intentguard as ig
-from validation.helpers import NullJudgementCache, PassthroughPromptFactory
+from validation.helpers import NullJudgementCache
 
 logger = logging.getLogger(__name__)
 
 
 def load_test_dataset():
-    return load_dataset("kdunee/IntentGuard-1-alpaca-format", split="test")
+    return load_dataset("kdunee/IntentGuard-1", split="test")
 
 
 def configure_validation_intentguard() -> None:
     ig.IntentGuard.set_judgement_cache_provider(NullJudgementCache())
-    ig.IntentGuard.set_prompt_factory(PassthroughPromptFactory())
 
 
-def validate_model():
+def _build_synthetic_module(
+    name: str, code: str, example_index: int, code_index: int
+) -> types.ModuleType:
+    safe_name = "".join(
+        char if char.isalnum() or char in "._-" else "_" for char in name
+    )
+    source = code if code.endswith("\n") else f"{code}\n"
+    filename = f"/intentguard_validation/example_{example_index:06d}_{code_index:02d}_{safe_name}.py"
+
+    # Seed linecache so inspect.getsource() can recover dataset snippets.
+    linecache.cache[filename] = (
+        len(source),
+        None,
+        source.splitlines(keepends=True),
+        filename,
+    )
+
+    module = types.ModuleType(name)
+    module.__file__ = filename
+    return module
+
+
+def _build_validation_params(
+    example: Dict[str, Any], example_index: int
+) -> Dict[str, object]:
+    params: Dict[str, object] = {}
+    for code_index, code_object in enumerate(example["codeObjects"]):
+        params[code_object["name"]] = _build_synthetic_module(
+            name=code_object["name"],
+            code=code_object["code"],
+            example_index=example_index,
+            code_index=code_index,
+        )
+    return params
+
+
+def validate_model(max_examples: Optional[int] = None):
     dataset = load_test_dataset()
+    total_examples = (
+        min(len(dataset), max_examples) if max_examples is not None else len(dataset)
+    )
 
     options = ig.IntentGuardOptions(num_evaluations=3, temperature=0.4)
     guard = ig.IntentGuard(options)
 
-    y_gt = []
+    y_true = []
     y_pred = []
-    for example in tqdm(dataset):
+    for example_index, example in enumerate(tqdm(dataset, total=total_examples)):
+        if max_examples is not None and example_index >= max_examples:
+            break
+
         try:
-            inp = example.get("input")
-            expected_result = json.loads(example.get("output"))["result"]
+            expectation = example["assertion"]["assertionText"]
+            params = _build_validation_params(example, example_index)
+            expected_result = example["explanation"] is None
             results = []
             for _ in range(5):
-                result = guard.test_code(inp, {}).result
+                result = guard.test_code(expectation, params).result
                 results.append(result)
             final_result = all(results)
-            y_gt.append(
-                not expected_result
-            )  # The dataset is inverted, we're looking for negative examples
-            y_pred.append(not final_result)
+            y_true.append(expected_result)
+            y_pred.append(final_result)
             logger.info(f"Expected: {expected_result}, Got: {final_result}")
         except Exception:
-            logger.exception("Error while processing example")
+            logger.exception("Error while processing example %d", example_index)
 
-    accuracy = sum([1 for gt, pred in zip(y_gt, y_pred) if gt == pred]) / len(y_gt)
-    precision = (
-        sum([1 for gt, pred in zip(y_gt, y_pred) if gt == pred and gt]) / sum(y_pred)
-        if sum(y_pred)
-        else 0
-    )
-    recall = (
-        sum([1 for gt, pred in zip(y_gt, y_pred) if gt == pred and gt]) / sum(y_gt)
-        if sum(y_gt)
-        else 0
-    )
+    if not y_true:
+        raise ValueError("Validation did not process any examples")
 
+    true_positives = sum(1 for gt, pred in zip(y_true, y_pred) if gt and pred)
+    predicted_positives = sum(y_pred)
+    actual_positives = sum(y_true)
+
+    accuracy = sum(1 for gt, pred in zip(y_true, y_pred) if gt == pred) / len(y_true)
+    precision = true_positives / predicted_positives if predicted_positives else 0
+    recall = true_positives / actual_positives if actual_positives else 0
+
+    logger.info(f"Processed examples: {len(y_true)}")
     logger.info(f"Accuracy: {accuracy}")
     logger.info(f"Precision: {precision}")
     logger.info(f"Recall: {recall}")


### PR DESCRIPTION
Switch validation off the dataset-embedded prompt path so it exercises the library end-to-end against the current dataset format, and remove the legacy passthrough prompt factory used only for the old validation flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated validation dataset source.
  * Streamlined validation configuration by removing unnecessary components.
  * Improved validation logic and metric computation.
  * Added optional parameter to control the number of examples processed during validation.
  * Enhanced error reporting with improved diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->