### PR TITLE
Add module-level IntentGuard API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ IntentGuard is a **library for natural-language code assertions**. Keep changes 
 
 ## What matters most
 
-- Public API surface is intentionally tiny: `IntentGuard` + `IntentGuardOptions`. Preserve this unless a task explicitly expands API.
+- Public API surface is intentionally tiny: `IntentGuard`, `IntentGuardOptions`, `assert_code`, `test_code`, and `set_default_options`. Preserve this unless a task explicitly expands API.
 - The runtime uses three replaceable collaborators:
   - `InferenceProvider` (model backend)
   - `PromptFactory` (prompt construction)

--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@ pip install intentguard
 import intentguard as ig
 
 def test_code_properties():
-    guard = ig.IntentGuard()
-
-    guard.assert_code(
+    ig.assert_code(
         "Classes in {module} should follow the Single Responsibility Principle",
         {"module": my_module}
     )
 
-    guard.assert_code(
+    ig.assert_code(
         "All database queries in {module} should be parameterized to prevent SQL injection",
         {"module": db_module}
     )
@@ -53,11 +51,8 @@ import unittest
 import intentguard as ig
 
 class TestCodeQuality(unittest.TestCase):
-    def setUp(self):
-        self.guard = ig.IntentGuard()
-
     def test_error_handling(self):
-        self.guard.assert_code(
+        ig.assert_code(
             "All API endpoints in {module} should have proper input validation",
             {"module": api_module}
         )
@@ -91,13 +86,17 @@ Configure repeatability:
 ```python
 import intentguard as ig
 
-options = ig.IntentGuardOptions(
-    num_evaluations=7,  # More evaluations make majority vote more stable
-    temperature=0.1,    # Lower temperature reduces sampling variance
+ig.set_default_options(
+    ig.IntentGuardOptions(
+        num_evaluations=7,  # More evaluations make majority vote more stable
+        temperature=0.1,    # Lower temperature reduces sampling variance
+    )
 )
-
-guard = ig.IntentGuard(options)
 ```
+
+Use module-level `ig.assert_code(...)` for ordinary tests. Use
+`ig.IntentGuard(options)` when one test class, suite, or subsystem needs isolated
+options.
 
 ## Model
 

--- a/intentguard/__init__.py
+++ b/intentguard/__init__.py
@@ -1,5 +1,6 @@
 from intentguard.app.intentguard import IntentGuard
 from intentguard.app.intentguard_options import IntentGuardOptions
+from intentguard.domain.evaluation import Evaluation as _Evaluation
 from intentguard.infrastructure.fs_judgement_cache import FsJudgementCache
 from intentguard.infrastructure.llamafile import Llamafile
 from intentguard.infrastructure.llamafile_prompt_factory import LlamafilePromptFactory
@@ -13,4 +14,31 @@ IntentGuard.set_inference_provider(llamafile)
 prompt_factory = LlamafilePromptFactory()
 IntentGuard.set_prompt_factory(prompt_factory)
 
-__all__ = ["IntentGuard", "IntentGuardOptions"]
+
+def test_code(
+    expectation: str,
+    params: dict[str, object],
+    options: IntentGuardOptions | None = None,
+) -> _Evaluation:
+    return IntentGuard().test_code(expectation, params, options)
+
+
+def assert_code(
+    expectation: str,
+    params: dict[str, object],
+    options: IntentGuardOptions | None = None,
+) -> None:
+    IntentGuard().assert_code(expectation, params, options)
+
+
+def set_default_options(options: IntentGuardOptions) -> None:
+    IntentGuard.set_default_options(options)
+
+
+__all__ = [
+    "IntentGuard",
+    "IntentGuardOptions",
+    "assert_code",
+    "set_default_options",
+    "test_code",
+]

--- a/intentguard/app/intentguard.py
+++ b/intentguard/app/intentguard.py
@@ -26,6 +26,18 @@ class IntentGuard:
     _inference_provider: InferenceProvider
     _prompt_factory: PromptFactory
     _judgement_cache_provider: JudgementCache
+    _default_options = IntentGuardOptions()
+
+    @classmethod
+    def set_default_options(cls, options: IntentGuardOptions) -> None:
+        """
+        Set process-wide default options for IntentGuard instances.
+
+        Args:
+            options: Configuration options used when no explicit options are provided.
+        """
+        logger.info("Setting default options: %s", options)
+        cls._default_options = options
 
     @classmethod
     def set_inference_provider(cls, inference_provider: InferenceProvider) -> None:
@@ -74,7 +86,7 @@ class IntentGuard:
         Args:
             options: Configuration options for assertions. Uses default options if None.
         """
-        self.options: IntentGuardOptions = options or IntentGuardOptions()
+        self.options: IntentGuardOptions = options or IntentGuard._default_options
         logger.debug("Initialized IntentGuard with options: %s", self.options)
 
     def test_code(

--- a/intentguard/app/intentguard_options.py
+++ b/intentguard/app/intentguard_options.py
@@ -23,3 +23,10 @@ class IntentGuardOptions:
         """
         self.num_evaluations: int = num_evaluations
         self.temperature: float = temperature
+
+    def __repr__(self) -> str:
+        return (
+            f"{self.__class__.__name__}("
+            f"num_evaluations={self.num_evaluations!r}, "
+            f"temperature={self.temperature!r})"
+        )

--- a/tests/test_module_api.py
+++ b/tests/test_module_api.py
@@ -1,0 +1,165 @@
+import unittest
+
+import intentguard as ig
+from intentguard.app.inference_options import InferenceOptions
+from intentguard.app.inference_provider import InferenceProvider
+from intentguard.app.judgement_cache import JudgementCache
+from intentguard.app.message import Message
+from intentguard.app.prompt_factory import PromptFactory
+from intentguard.domain.code_object import CodeObject
+from intentguard.domain.evaluation import Evaluation
+from intentguard.domain.judgement_options import JudgementOptions
+
+
+def sample_subject() -> None:
+    pass
+
+
+class FakeInferenceProvider(InferenceProvider):
+    def __init__(self, result: Evaluation) -> None:
+        self.result = result
+        self.inference_options: list[InferenceOptions] = []
+
+    def predict(
+        self, prompt: list[Message], inference_options: InferenceOptions
+    ) -> Evaluation:
+        self.inference_options.append(inference_options)
+        return self.result
+
+
+class FakePromptFactory(PromptFactory):
+    def create_prompt(
+        self, expectation: str, code_objects: list[CodeObject]
+    ) -> list[Message]:
+        return [Message(content=expectation, role="user")]
+
+
+class NoopJudgementCache(JudgementCache):
+    def get(
+        self,
+        prompt: list[Message],
+        inference_options: InferenceOptions,
+        judgement_options: JudgementOptions,
+    ) -> Evaluation | None:
+        return None
+
+    def put(
+        self,
+        prompt: list[Message],
+        inference_options: InferenceOptions,
+        judgement_options: JudgementOptions,
+        judgement: Evaluation,
+    ) -> None:
+        pass
+
+
+class ModuleApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.original_inference_provider = ig.IntentGuard._inference_provider
+        self.original_prompt_factory = ig.IntentGuard._prompt_factory
+        self.original_judgement_cache = ig.IntentGuard._judgement_cache_provider
+        self.original_default_options = ig.IntentGuard._default_options
+
+        self.provider = FakeInferenceProvider(Evaluation(result=True, explanation=None))
+        ig.IntentGuard.set_inference_provider(self.provider)
+        ig.IntentGuard.set_prompt_factory(FakePromptFactory())
+        ig.IntentGuard.set_judgement_cache_provider(NoopJudgementCache())
+        ig.set_default_options(ig.IntentGuardOptions())
+
+    def tearDown(self) -> None:
+        ig.IntentGuard.set_inference_provider(self.original_inference_provider)
+        ig.IntentGuard.set_prompt_factory(self.original_prompt_factory)
+        ig.IntentGuard.set_judgement_cache_provider(self.original_judgement_cache)
+        ig.IntentGuard.set_default_options(self.original_default_options)
+
+    def test_module_test_code_returns_evaluation(self) -> None:
+        evaluation = ig.test_code("sample should pass", {"subject": sample_subject})
+
+        self.assertIsInstance(evaluation, Evaluation)
+        self.assertTrue(evaluation.result)
+
+    def test_module_assert_code_succeeds_when_judgement_is_true(self) -> None:
+        ig.assert_code("sample should pass", {"subject": sample_subject})
+
+        self.assertEqual(1, len(self.provider.inference_options))
+
+    def test_module_assert_code_raises_existing_format_when_false(self) -> None:
+        self.provider.result = Evaluation(result=False, explanation="sample failed")
+
+        with self.assertRaises(AssertionError) as cm:
+            ig.assert_code("sample should pass", {"subject": sample_subject})
+
+        self.assertEqual(
+            'Expected "sample should pass" to be true, but it was false.\n'
+            "Explanation: sample failed",
+            str(cm.exception),
+        )
+
+    def test_default_options_affect_module_level_calls(self) -> None:
+        ig.set_default_options(
+            ig.IntentGuardOptions(num_evaluations=3, temperature=0.2)
+        )
+
+        ig.test_code("sample should pass", {"subject": sample_subject})
+
+        self.assertEqual(3, len(self.provider.inference_options))
+        self.assertEqual(
+            [0.2, 0.2, 0.2],
+            [options.temperature for options in self.provider.inference_options],
+        )
+
+    def test_per_call_options_override_defaults(self) -> None:
+        ig.set_default_options(
+            ig.IntentGuardOptions(num_evaluations=3, temperature=0.2)
+        )
+
+        ig.test_code(
+            "sample should pass",
+            {"subject": sample_subject},
+            options=ig.IntentGuardOptions(num_evaluations=1, temperature=0.7),
+        )
+
+        self.assertEqual(1, len(self.provider.inference_options))
+        self.assertEqual(0.7, self.provider.inference_options[0].temperature)
+
+    def test_explicit_instance_options_override_defaults(self) -> None:
+        ig.set_default_options(
+            ig.IntentGuardOptions(num_evaluations=3, temperature=0.2)
+        )
+        guard = ig.IntentGuard(
+            ig.IntentGuardOptions(num_evaluations=2, temperature=0.6)
+        )
+
+        guard.test_code("sample should pass", {"subject": sample_subject})
+
+        self.assertEqual(2, len(self.provider.inference_options))
+        self.assertEqual(
+            [0.6, 0.6],
+            [options.temperature for options in self.provider.inference_options],
+        )
+
+    def test_empty_instance_uses_updated_defaults(self) -> None:
+        ig.set_default_options(
+            ig.IntentGuardOptions(num_evaluations=4, temperature=0.3)
+        )
+        guard = ig.IntentGuard()
+
+        guard.test_code("sample should pass", {"subject": sample_subject})
+
+        self.assertEqual(4, len(self.provider.inference_options))
+        self.assertEqual(
+            [0.3, 0.3, 0.3, 0.3],
+            [options.temperature for options in self.provider.inference_options],
+        )
+
+    def test_options_repr_includes_configured_values(self) -> None:
+        options = ig.IntentGuardOptions(num_evaluations=7, temperature=0.1)
+
+        self.assertEqual(
+            "IntentGuardOptions(num_evaluations=7, temperature=0.1)",
+            repr(options),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Expose assert_code, test_code, and process-wide default options while preserving explicit IntentGuard instance configuration.